### PR TITLE
fix mismatched context bug

### DIFF
--- a/Grocemate/Views/CardDetailView/CardDetailView.swift
+++ b/Grocemate/Views/CardDetailView/CardDetailView.swift
@@ -180,7 +180,7 @@ struct CardDetailView<ViewModel: CardDetailViewModellable>: View {
                 coreDataController: preview
             )
         )
-        .environment(\.managedObjectContext, preview.newContext)
+        .environment(\.managedObjectContext, preview.viewContext)
     }()
 
     return viewToPreview

--- a/Grocemate/Views/CardDetailView/CreateCardView/CreateCardViewModel.swift
+++ b/Grocemate/Views/CardDetailView/CreateCardView/CreateCardViewModel.swift
@@ -30,11 +30,12 @@ final class CreateCardViewModel: ObservableObject, CardDetailViewModellable {
     init(coreDataController: CoreDataController) {
         /// We will use a new context as a temporary editing board outside
         /// the main view context.
-        self.context = coreDataController.newContext
-        self.card = IngredientCard(context: coreDataController.newContext)
+        let newContext = coreDataController.newContext
+        self.context = newContext
+        self.card = IngredientCard(context: newContext)
         self.title = "New Card"
         self.ingredients = [
-            Ingredient(context: self.context)
+            Ingredient(context: newContext)
         ]
     }
 
@@ -44,11 +45,12 @@ final class CreateCardViewModel: ObservableObject, CardDetailViewModellable {
     ) {
         /// We will use a new context as a temporary editing board outside
         /// the main view context.
-        self.context = coreDataController.newContext
-        self.card = IngredientCard(context: coreDataController.newContext)
+        let newContext = coreDataController.newContext
+        self.context = newContext
+        self.card = IngredientCard(context: newContext)
         self.title = tempCard.title
         self.ingredients = tempCard.ingredients.map({ ingredientName in
-            let newIngredient = Ingredient(context: coreDataController.newContext)
+            let newIngredient = Ingredient(context: newContext)
             newIngredient.name = ingredientName
             return newIngredient
         })
@@ -92,7 +94,7 @@ final class CreateCardViewModel: ObservableObject, CardDetailViewModellable {
         setIngredientsToCard()
 
         do {
-            try CoreDataController.shared.persist(in: context)
+            try CoreDataController.shared.persist(in: self.context)
         } catch {
             print("An error occurred saving the card: \(error.localizedDescription)")
         }


### PR DESCRIPTION
Fixed bug which produced the following:
1. "Mutating a managed object after it was removed from its context" 
2. Crashes due to trying to combine/save objects in different contexts.

Cause:
1. Accessing the computed property newContext in CoreDataController produces a new context every time. CreateCardViewModel was accessing the property multiple times and thus creating objects in many different contexts. Solution was to access once and save a reference to the returned context and use that throughout the initializer.